### PR TITLE
Added missing prereqs as suggested by CPANTS.

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -7,6 +7,9 @@ requires 'MooseX::Getopt';
 requires 'SQS::Worker', '0.05';
 requires 'MooseX::App';
 requires 'Log::Log4perl';
+requires 'Path::Class';
+requires 'Paws';
+requires 'namespace::autoclean';
 
 on 'develop' => sub {
   requires 'Test::Spec';


### PR DESCRIPTION
Hi @pplu 

Please review the PR.

      prereq_matches_use
      List all used modules in META.yml requires

      Error:

           Path::Class
           Paws
           namespace::autoclean

Many Thanks.
Best Regards,
Mohanmad S Anwar